### PR TITLE
Bugfix of cardinality for ERMS208

### DIFF
--- a/schema/ERMS.xsd
+++ b/schema/ERMS.xsd
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+<!-- E-ARK ERMS schema version 2.1.1 2022-06-20 -->
 <!-- E-ARK ERMS schema version 2.1 2021-08-31 -->
 <!-- E-ARK ERMS schema version 2.0 2020-08-01 -->
 <!-- Chganges includes correction of elements name and camelcasing, valuelist corrections and lowercase and underscore used instead of spaces.-->


### PR DESCRIPTION
The cardinality maximum needs to be unbounded for the classification in the aggregation following CITS ERMS. Thus the schema has been updated to allow this.

Closes #16 