### PR TITLE
Update of cardinality following issue 51

### DIFF
--- a/schema/ERMS_v3.xsd
+++ b/schema/ERMS_v3.xsd
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+<!-- E-ARK ERMS schema version 3.0.2 2024-12-10 -->
 <!-- E-ARK ERMS schema version 3.0.1 2024-08-22 -->
 <!-- E-ARK ERMS schema version 3.0.0 2024-05-17 -->
 <!-- E-ARK ERMS schema version 2.1.3 2023-11-03 -->
@@ -1056,7 +1057,8 @@
 
     <xs:complexType name="systemInfoType">
         <xs:annotation>
-            <xs:documentation xml:lang="en">DEfintion of the system information is exported in its own XML-format</xs:documentation>
+            <xs:documentation xml:lang="en">Defintion of the system information is exported in its own XML-format</xs:documentation>
+            <xs:documentation xml:lang="en">2024-12-10 update to allow unlimited of occurs for the agents/agent element</xs:documentation>
         </xs:annotation>
         <xs:sequence>
             <xs:element name="extraMetadataInformation" type="extendingComplexType" minOccurs="0">
@@ -1070,7 +1072,7 @@
                 </xs:annotation>
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element name="agent" type="agentComplexType" minOccurs="0"/>
+                        <xs:element name="agent" type="agentComplexType" minOccurs="0" maxOccurs="unbounded"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>


### PR DESCRIPTION
The maxoccurs value for the agent child element of agents was set to one instead of its in the specification stated unlimitted.

Closes #51 